### PR TITLE
Update two userscripts for better performance

### DIFF
--- a/english-microsoft-docs.js
+++ b/english-microsoft-docs.js
@@ -1,14 +1,13 @@
 // ==UserScript==
 // @name         English Microsoft Docs
-// @version      0.1
+// @version      0.2
 // @description  Automatically switches to english Microsoft docs
-// @author       Twometer
-// @match        https://*/*
+// @author       Twometer, Daniel Lerch
+// @match        https://docs.microsoft.com/de-de*
 // @grant        none
 // ==/UserScript==
 
 (function() {
     'use strict';
-    if(window.location.href.startsWith("https://docs.microsoft.com/de-de"))
-        window.location.href = window.location.href.replace("https://docs.microsoft.com/de-de", "https://docs.microsoft.com/en-us");
+    window.location.href = window.location.href.replace("https://docs.microsoft.com/de-de", "https://docs.microsoft.com/en-us");
 })();

--- a/spiegel-online-adblocker.js
+++ b/spiegel-online-adblocker.js
@@ -1,9 +1,10 @@
 // ==UserScript==
-// @name         Twometer Spiegel & Chip Deblock
-// @version      0.3
+// @name         Spiegel & Chip Deblock
+// @version      0.4
 // @description  Spiegel Online & Chip Ad Blocker Blocker Blocker
-// @author       Twometer Applications
-// @match        *://*/*
+// @author       Twometer, Daniel Lerch
+// @include      http://www.spiegel.de/*
+// @include      https://www.chip.de/*
 // @grant        none
 // ==/UserScript==
 
@@ -15,7 +16,7 @@
     var detected = false;
 
     let intervalId = setInterval(() => {
-        if(window.uabpFlags || document.location.href.startsWith("http://www.chip.de")) {
+        if(window.uabpFlags || document.location.href.startsWith("https://www.chip.de")) {
             if(!detected) {
                 console.log("[UABP DEBLOCK] Detected ad block detector");
                 detected = true;


### PR DESCRIPTION
Now using url match of TamperMonkey instead of JavaScript check.
Spiegel Online & Chip now using `@include` instead of running on any site.